### PR TITLE
Flush file buffer before closing dataSocket

### DIFF
--- a/lib/src/commands/fileupload.dart
+++ b/lib/src/commands/fileupload.dart
@@ -67,6 +67,7 @@ class FileUpload {
 
     _log.log('Uploaded: $iRead B');
 
+    fRAFile.flushSync();
     dataSocket.closeSync();
     fRAFile.closeSync();
 


### PR DESCRIPTION
Otherwise, there might be some data left that was not yet written into the dataSocket and uploaded files are corrupted

This fixes #7 