### PR TITLE
Wait for server to process upload

### DIFF
--- a/lib/src/ftpclient_base.dart
+++ b/lib/src/ftpclient_base.dart
@@ -52,9 +52,10 @@ class FTPClient {
   }
 
   /// Upload the File [fFile] to the current directory
-  void uploadFile(File fFile,
-      {String sRemoteName = '', TransferMode mode = TransferMode.binary}) {
-    FileUpload(_socket, _bufferSize, mode, _log).uploadFile(fFile, sRemoteName);
+  Future<void> uploadFile(File fFile,
+      {String sRemoteName = '',
+      TransferMode mode = TransferMode.binary}) async {
+    await FileUpload(_socket, mode, _log).uploadFile(fFile, sRemoteName);
   }
 
   /// Download the Remote File [sRemoteName] to the local File [fFile]


### PR DESCRIPTION
I am very sorry to screw this up #7 #11  in the first try. But I tested this new solution like a million times and the files always arrived correctly. It was tricky because the original code did not wait for the server to have processed all data from the data socket. The second wait was optional, which was wrong. Because there, the server tells the client that it fully processed data from the data channel. In addition to that, the synchronous manual copy&pasta code into the sync raw buffer did also not work out. Sorry, I broke the API now by making it asynchronous, but this is now super easy and works. It just pipes a stream into a socket, that's it. No manual copying around.

What was the reasoning to make everything synchronous?